### PR TITLE
Fix Vercel deployment configuration

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -9,16 +9,5 @@
   ],
   "routes": [
     { "src": "/(.*)", "dest": "/index.html" }
-  ],
-  "headers": [
-    {
-      "source": "/(.*\\.js)",
-      "headers": [
-        {
-          "key": "Content-Type",
-          "value": "application/javascript; charset=utf-8"
-        }
-      ]
-    }
   ]
 }


### PR DESCRIPTION
Update `vercel.json` to fix launch and work on Vercel.

* Remove the `headers` section that sets the `Content-Type` for JavaScript files.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/shams3049/little-hill/pull/2?shareId=effda045-5928-4dcb-b9a7-83d2e42b6df7).